### PR TITLE
Upgrading material-dialogs version and adding checkBoxPrompt to picker

### DIFF
--- a/DialogAndroid.js
+++ b/DialogAndroid.js
@@ -345,9 +345,13 @@ class DialogAndroid {
                     }
                     case 'itemsCallback':
                     case 'itemsCallbackSingleChoice': {
-                        const [ selectedIndex ] = rest;
+                        const [ selectedIndex, selectedLabel, isPromptCheckBoxChecked ] = rest;
                         const selectedItem = items[selectedIndex];
-                        return resolve({ action:DialogAndroid.actionSelect, selectedItem });
+                        return resolve({
+                          action: DialogAndroid.actionSelect,
+                          selectedItem,
+                          isPromptCheckBoxChecked
+                        });
                     }
                     case 'onAny': {
                         const [ dialogAction ] = rest;

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,5 +31,5 @@ dependencies {
     compile 'com.facebook.react:react-native:+'
     compile fileTree(include: ['*.jar'], dir: 'libs')
     testCompile 'junit:junit:4.12'
-    compile 'com.afollestad.material-dialogs:commons:0.8.6.2'
+    compile 'com.afollestad.material-dialogs:commons:0.9.0.1'
 }

--- a/android/src/main/java/com/aakashns/reactnativedialogs/modules/DialogAndroid.java
+++ b/android/src/main/java/com/aakashns/reactnativedialogs/modules/DialogAndroid.java
@@ -11,6 +11,7 @@ import com.afollestad.materialdialogs.GravityEnum;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.afollestad.materialdialogs.simplelist.MaterialSimpleListAdapter;
 import com.afollestad.materialdialogs.simplelist.MaterialSimpleListItem;
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -163,6 +164,12 @@ public class DialogAndroid extends ReactContextBaseJavaModule {
                         builder.btnStackedGravity(GravityEnum.START);
                     }
                     break;
+                case "checkBoxPrompt":
+                    ReadableMap checkBoxPrompt = options.getMap("checkBoxPrompt");
+                    boolean initiallyChecked = checkBoxPrompt.hasKey("initiallyChecked") &&
+                            checkBoxPrompt.getBoolean("initiallyChecked");
+                    builder.checkBoxPrompt(checkBoxPrompt.getString("text"), initiallyChecked, null);
+                    break;
                 case "progress":
                     ReadableMap progress = options.getMap("progress");
                     boolean indeterminate = progress.hasKey("indeterminate") &&
@@ -275,7 +282,8 @@ public class DialogAndroid extends ReactContextBaseJavaModule {
                             if (!mCallbackConsumed) {
                                 mCallbackConsumed = true;
                                 charSequence = charSequence == null ? "" : charSequence;
-                                callback.invoke("itemsCallbackSingleChoice", i, charSequence.toString());
+                                boolean isPromptCheckBoxChecked = materialDialog.isPromptCheckBoxChecked();
+                                callback.invoke("itemsCallbackSingleChoice", i, charSequence.toString(), isPromptCheckBoxChecked);
                             }
                             return true;
                         }
@@ -407,7 +415,18 @@ public class DialogAndroid extends ReactContextBaseJavaModule {
     MaterialDialog simple;
     @ReactMethod
     public void list(ReadableMap options, final Callback callback) {
-        final MaterialSimpleListAdapter simpleListAdapter = new MaterialSimpleListAdapter(getCurrentActivity());
+        final MaterialSimpleListAdapter simpleListAdapter = new MaterialSimpleListAdapter(new MaterialSimpleListAdapter.Callback() {
+            @Override
+            public void onMaterialListItemSelected(int index, MaterialSimpleListItem item) {
+                if (!mCallbackConsumed) {
+                    mCallbackConsumed = true;
+                    callback.invoke(index, item.getContent());
+                }
+                if (simple != null) {
+                    simple.dismiss();
+                }
+            }
+        });
 
         ReadableArray arr = options.getArray("items");
         for(int i = 0; i < arr.size(); i++){
@@ -418,18 +437,7 @@ public class DialogAndroid extends ReactContextBaseJavaModule {
 
         final MaterialDialog.Builder adapter = new MaterialDialog.Builder(getCurrentActivity())
                 .title(options.hasKey("title") ? options.getString("title") : "")
-                .adapter(simpleListAdapter, new MaterialDialog.ListCallback() {
-                    @Override
-                    public void onSelection(MaterialDialog dialog, View itemView, int which, CharSequence text) {
-                        if (!mCallbackConsumed) {
-                            mCallbackConsumed = true;
-                            callback.invoke(which, text);
-                        }
-                        if (simple != null) {
-                            simple.dismiss();
-                        }
-                    }
-                })
+                .adapter(simpleListAdapter, null)
                 .autoDismiss(true);
 
         UiThreadUtil.runOnUiThread(new Runnable() {


### PR DESCRIPTION
I needed the checkbox prompt functionality, so I upgraded the library version and included the checkbox information on the callback of the picker.

Maybe it could be implemented in a more generic way, to all the callbacks. Tell me what you think about it.